### PR TITLE
Change showStatusPageOnSubmit to use default browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "chalk": "^4.1.0",
         "express": "^4.17.1",
-        "playwright-chromium": "^1.9.1",
+        "open": "^8.0.8",
+        "playwright-chromium": "^1.11.0",
         "update-notifier": "^4.1.0",
         "yargs": "^15.4.0"
       },
@@ -723,6 +724,14 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1251,6 +1260,20 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1329,6 +1352,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-yarn-global": {
       "version": "0.3.0",
@@ -1568,6 +1602,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.8.tgz",
+      "integrity": "sha512-3XmKIU8+H/TVr8wB8C4vj0z748+yBydSvtpzZVS6vQ1dKNHB6AiPbhaoG+89zb80717GPk9y/7OvK0R6FXkNmQ==",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -1672,9 +1722,9 @@
       }
     },
     "node_modules/playwright-chromium": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.9.1.tgz",
-      "integrity": "sha512-D3dc7Nk7LDkvlnZtum9+PGk1QX85rPDH8R6hTfkpHU1rDbb1iOVa2dpDwJ5LNI7Po1X/q0x8v40LeeGfA9lIAg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.11.0.tgz",
+      "integrity": "sha512-CNV58vXoyItAXOuK9rgyESBmnwVMnQg12TBJEDq1IksJo9m2Gi1maReiMOOJAFduMhicvLGgRsQfdzm44KCcxA==",
       "hasInstallScript": true,
       "dependencies": {
         "commander": "^6.1.0",
@@ -1689,13 +1739,14 @@
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.3.1",
+        "yazl": "^2.5.1"
       },
       "bin": {
         "playwright": "lib/cli/cli.js"
       },
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=12"
       }
     },
     "node_modules/playwright-chromium/node_modules/debug": {
@@ -2483,9 +2534,9 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/yargs": {
       "version": "15.4.0",
@@ -2535,6 +2586,14 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "node_modules/yn": {
@@ -3130,6 +3189,11 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3545,6 +3609,11 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3599,6 +3668,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -3780,6 +3857,16 @@
         "wrappy": "1"
       }
     },
+    "open": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.8.tgz",
+      "integrity": "sha512-3XmKIU8+H/TVr8wB8C4vj0z748+yBydSvtpzZVS6vQ1dKNHB6AiPbhaoG+89zb80717GPk9y/7OvK0R6FXkNmQ==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -3856,9 +3943,9 @@
       "dev": true
     },
     "playwright-chromium": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.9.1.tgz",
-      "integrity": "sha512-D3dc7Nk7LDkvlnZtum9+PGk1QX85rPDH8R6hTfkpHU1rDbb1iOVa2dpDwJ5LNI7Po1X/q0x8v40LeeGfA9lIAg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.11.0.tgz",
+      "integrity": "sha512-CNV58vXoyItAXOuK9rgyESBmnwVMnQg12TBJEDq1IksJo9m2Gi1maReiMOOJAFduMhicvLGgRsQfdzm44KCcxA==",
       "requires": {
         "commander": "^6.1.0",
         "debug": "^4.1.1",
@@ -3872,7 +3959,8 @@
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.3.1",
+        "yazl": "^2.5.1"
       },
       "dependencies": {
         "debug": {
@@ -4479,9 +4567,9 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yargs": {
       "version": "15.4.0",
@@ -4524,6 +4612,14 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "requires": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "express": "^4.17.1",
-    "playwright-chromium": "^1.9.1",
+    "open": "^8.0.8",
+    "playwright-chromium": "^1.11.0",
     "update-notifier": "^4.1.0",
     "yargs": "^15.4.0"
   }

--- a/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -23,6 +23,7 @@ import { exit } from "process";
 import GlobalConstants from "../../GlobalConstants";
 import Config from "../../Config/Config";
 import { LangAliases } from "../../Config/Types/LangAliases";
+import open from "open";
 
 export enum OnlineJudgeName {
   codeforces = "codeforces",
@@ -119,13 +120,7 @@ export default abstract class OnlineJudge {
 
   async openBrowserInUrl(url: string) {
     try {
-      let browser = await chromium.launch({ headless: false });
-      const context = await this.restoreSession(browser);
-      context.on("page", (_) => this.closeAllOtherTabs(context));
-      const pages = context.pages();
-      let page = pages.length > 0 ? pages[0] : await context.newPage();
-      page.on("close", (_) => exit(0));
-      await page.goto(url);
+      await open(url);
     } catch (_) {
       // This line apparently never gets executed
       console.log("Browser closed");


### PR DESCRIPTION
Liked the idea of cpbooster and decided to try it out. I really liked it, however I had a small issue that when the showStatusPageOnSubmit config option is set to true, the submission page opens in chromium.

For me it would be more convenient if the submission page opened in my default browser (Firefox), which i am using the competitive companion extension in to begin with.

Hence i decided to try contributing, found an NPM package [open](https://github.com/sindresorhus/open) that can open URLs in the default browser and changed the function which was used to open the submission page after submitting.

I do not know if this change resonates with others but in case it does i am making this PR.