### PR TITLE
Alacritty terminal support

### DIFF
--- a/src/Clone/TerminalCommandBuilder.ts
+++ b/src/Clone/TerminalCommandBuilder.ts
@@ -1,5 +1,7 @@
 export function getTerminalCommand(terminalName: string, contestPath: string): string | null {
   switch (terminalName) {
+    case "alacritty":
+      return `alacritty --working-directory="${contestPath}" & disown`;
     case "konsole":
       return `konsole --workdir "${contestPath}"`;
     case "gnome-terminal":


### PR DESCRIPTION
Alacritty terminal support in `TerminalCommandBuilder`

I am not sure if is the only file to look up for this terminal support.

Behavior: Opens a new `alacritty` terminal in a `working directory` specify; with disown (so if the command is run by another terminal, closing this does not kill the process.