### PR TITLE
Add omegup online judge

### DIFF
--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -54,7 +54,8 @@ export default class Config {
         debugCommand: "g++ -std=gnu++17 -DDEBUG -Wshadow -Wall",
         aliases: {
           codeforces: "54",
-          atcoder: "4003"
+          atcoder: "4003",
+          omegaup: "cpp17-gcc"
         }
       },
       py: {
@@ -63,7 +64,8 @@ export default class Config {
         debugCommand: "python3 -O",
         aliases: {
           codeforces: "31",
-          atcoder: "4006"
+          atcoder: "4006",
+          omegaup: "py3"
         }
       }
     };

--- a/app/src/Config/Types/LangAliases.ts
+++ b/app/src/Config/Types/LangAliases.ts
@@ -1,4 +1,5 @@
 export type LangAliases = {
   codeforces?: string;
   atcoder?: string;
+  omegaup?: string;
 };

--- a/app/src/Submit/OnlineJudgeFactory/OmegaUp.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OmegaUp.ts
@@ -1,0 +1,45 @@
+/*
+    cpbooster "Competitive Programming Booster"
+    Copyright (C) 2020  Sergio G. Sanchez V.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Page } from "playwright-chromium";
+import OnlineJudge, { OnlineJudgeName } from "./OnlineJudge";
+
+export default class Codeforces extends OnlineJudge {
+  readonly onlineJudgeName = OnlineJudgeName.omegaup;
+  readonly loginUrl = "https://omegaup.com/login/";
+  readonly blockedResourcesOnSubmit: Set<string> = new Set(["image", "font"]);
+
+  async isLoggedIn(page: Page): Promise<boolean> {
+    const querySelector = "a[href*=logout]";
+    return (await page.$(querySelector)) !== null;
+  }
+
+  async uploadFile(filePath: string, page: Page, langAlias: string): Promise<boolean> {
+    try {
+      await page.click("a[href*=new-run]");
+      const inputFile = await page.$("input[type=file]");
+      if (inputFile) await inputFile.setInputFiles(filePath);
+      await page.selectOption("select", { value: langAlias });
+      await page.click('button[type=submit][class="btn btn-primary"]');
+      return true;
+    } catch (e) {
+      console.log(e);
+      return false;
+    }
+  }
+}

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -126,6 +126,8 @@ export default abstract class OnlineJudge {
         return langAliases?.codeforces;
       case OnlineJudgeName.atcoder:
         return langAliases?.atcoder;
+      case OnlineJudgeName.omegaup:
+        return langAliases?.omegaup;
       default:
         return undefined;
     }

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -27,7 +27,8 @@ import open from "open";
 
 export enum OnlineJudgeName {
   codeforces = "codeforces",
-  atcoder = "atcoder"
+  atcoder = "atcoder",
+  omegaup = "omegaup"
 }
 
 export default abstract class OnlineJudge {

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
@@ -19,6 +19,7 @@
 import { exit } from "process";
 import AtCoder from "./AtCoder";
 import Codeforces from "./Codeforces";
+import OmegaUp from "./OmegaUp";
 import OnlineJudge from "./OnlineJudge";
 
 export default class OnlineJudgeFactory {
@@ -28,6 +29,8 @@ export default class OnlineJudgeFactory {
       return new Codeforces();
     } else if (url.includes("atcoder")) {
       return new AtCoder();
+    } else if (url.includes("omegaup")) {
+      return new OmegaUp();
     } else {
       console.log("Online Judge not supported");
       exit(0);


### PR DESCRIPTION
What does this PR do?

It adds support to submit files to OmegaUp Online judge.

Note: OmegaUp just supports one session at a time, so opening statusPage in user's default browser will not work, use "playwright" instead, which is shipped with `cpbooster` installation.