### PR TITLE
Support official.contest.yandex.com

### DIFF
--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -62,7 +62,8 @@ export default class Config {
         aliases: {
           codeforces: "54",
           atcoder: "4003",
-          omegaup: "cpp17-gcc"
+          omegaup: "cpp17-gcc",
+          yandex: "gcc7_3"
         },
         type: "compiled",
         commentString: "//"

--- a/app/src/Config/Types/LangAliases.ts
+++ b/app/src/Config/Types/LangAliases.ts
@@ -2,4 +2,5 @@ export type LangAliases = {
   codeforces?: string;
   atcoder?: string;
   omegaup?: string;
+  yandex?: string;
 };

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -29,7 +29,8 @@ import Util from "../../Utils/Util";
 export enum OnlineJudgeName {
   codeforces = "codeforces",
   atcoder = "atcoder",
-  omegaup = "omegaup"
+  omegaup = "omegaup",
+  yandex = "yandex" 
 }
 
 export default abstract class OnlineJudge {
@@ -118,6 +119,8 @@ export default abstract class OnlineJudge {
         return langAliases?.atcoder;
       case OnlineJudgeName.omegaup:
         return langAliases?.omegaup;
+      case OnlineJudgeName.yandex:
+        return langAliases?.yandex;
       default:
         return undefined;
     }

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
@@ -20,6 +20,7 @@ import { exit } from "process";
 import AtCoder from "./AtCoder";
 import Codeforces from "./Codeforces";
 import OmegaUp from "./OmegaUp";
+import Yandex from "./Yandex";
 import OnlineJudge from "./OnlineJudge";
 
 export default class OnlineJudgeFactory {
@@ -31,6 +32,8 @@ export default class OnlineJudgeFactory {
       return new AtCoder();
     } else if (url.includes("omegaup")) {
       return new OmegaUp();
+    } else if (url.includes("official.contest.yandex")) {
+      return new Yandex(); 
     } else {
       console.log("Online Judge not supported");
       exit(0);

--- a/app/src/Submit/OnlineJudgeFactory/Yandex.ts
+++ b/app/src/Submit/OnlineJudgeFactory/Yandex.ts
@@ -1,0 +1,50 @@
+/*
+    cpbooster "Competitive Programming Booster"
+    Copyright (C) 2020  Sergio G. Sanchez V.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Page } from "playwright-chromium";
+import OnlineJudge, { OnlineJudgeName } from "./OnlineJudge";
+
+export default class Yandex extends OnlineJudge {
+  readonly onlineJudgeName = OnlineJudgeName.yandex;
+  readonly loginUrl = "https://official.contest.yandex.com/login";
+  readonly blockedResourcesOnSubmit: Set<string> = new Set(["image", "stylesheet", "font"]);
+
+  async isLoggedIn(page: Page): Promise<boolean> {
+    const querySelector = "form[action*=logout]";
+    return (await page.$(querySelector)) !== null;
+  }
+
+  async uploadFile(filePath: string, page: Page, langAlias: string): Promise<boolean> {
+    try {
+      await page.selectOption("select", { value: langAlias });
+      await page.click("input[value=file]")
+      const inputFile = await page.$("input[type=file]");
+      if (inputFile) await inputFile.setInputFiles(filePath);
+      await page.click("div.problem__send > button");
+      await page.waitForLoadState("load");
+      if ((await page.$("div[class*=msg_type_warn]")) !== null) {
+        console.log("\nYou have submitted exactly the same code before\n");
+        return false;
+      } else {
+        return true;
+      }
+    } catch (e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Implements submission system for official.contest.yandex.com (mostly used for opencup). Note that official.contest.yandex.ru  doesn't work. And contest.yandex.com/ru has entirely different login system. 
