### PR TITLE
Support szkopul

### DIFF
--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -63,6 +63,7 @@ export default class Config {
           codeforces: "54",
           atcoder: "4003",
           omegaup: "cpp17-gcc",
+          szkopul: "-",
           yandex: "gcc7_3"
         },
         type: "compiled",
@@ -75,7 +76,8 @@ export default class Config {
         aliases: {
           codeforces: "31",
           atcoder: "4006",
-          omegaup: "py3"
+          omegaup: "py3",
+          szkopul: "-"
         },
         type: "interpreted",
         commentString: "#"

--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -63,7 +63,7 @@ export default class Config {
           codeforces: "54",
           atcoder: "4003",
           omegaup: "cpp17-gcc",
-          szkopul: "-",
+          szkopul: "C++",
           yandex: "gcc7_3"
         },
         type: "compiled",
@@ -77,7 +77,7 @@ export default class Config {
           codeforces: "31",
           atcoder: "4006",
           omegaup: "py3",
-          szkopul: "-"
+          szkopul: "Python"
         },
         type: "interpreted",
         commentString: "#"

--- a/app/src/Config/Types/LangAliases.ts
+++ b/app/src/Config/Types/LangAliases.ts
@@ -2,5 +2,6 @@ export type LangAliases = {
   codeforces?: string;
   atcoder?: string;
   omegaup?: string;
+  szkopul?: string;
   yandex?: string;
 };

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -31,7 +31,7 @@ export enum OnlineJudgeName {
   atcoder = "atcoder",
   omegaup = "omegaup",
   szkopul = "szkopul",
-  yandex = "yandex" 
+  yandex = "yandex"
 }
 
 export default abstract class OnlineJudge {

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -30,6 +30,7 @@ export enum OnlineJudgeName {
   codeforces = "codeforces",
   atcoder = "atcoder",
   omegaup = "omegaup",
+  szkopul = "szkopul",
   yandex = "yandex" 
 }
 
@@ -119,6 +120,8 @@ export default abstract class OnlineJudge {
         return langAliases?.atcoder;
       case OnlineJudgeName.omegaup:
         return langAliases?.omegaup;
+      case OnlineJudgeName.szkopul:
+        return langAliases?.szkopul;
       case OnlineJudgeName.yandex:
         return langAliases?.yandex;
       default:

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
@@ -20,6 +20,7 @@ import { exit } from "process";
 import AtCoder from "./AtCoder";
 import Codeforces from "./Codeforces";
 import OmegaUp from "./OmegaUp";
+import Szkopul from "./Szkopul";
 import Yandex from "./Yandex";
 import OnlineJudge from "./OnlineJudge";
 
@@ -32,6 +33,8 @@ export default class OnlineJudgeFactory {
       return new AtCoder();
     } else if (url.includes("omegaup")) {
       return new OmegaUp();
+    } else if (url.includes("szkopul.edu.pl")) {
+      return new Szkopul();
     } else if (url.includes("official.contest.yandex")) {
       return new Yandex(); 
     } else {

--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudgeFactory.ts
@@ -36,7 +36,7 @@ export default class OnlineJudgeFactory {
     } else if (url.includes("szkopul.edu.pl")) {
       return new Szkopul();
     } else if (url.includes("official.contest.yandex")) {
-      return new Yandex(); 
+      return new Yandex();
     } else {
       console.log("Online Judge not supported");
       exit(0);

--- a/app/src/Submit/OnlineJudgeFactory/Szkopul.ts
+++ b/app/src/Submit/OnlineJudgeFactory/Szkopul.ts
@@ -1,0 +1,49 @@
+/*
+    cpbooster "Competitive Programming Booster"
+    Copyright (C) 2022  ???
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Page } from "playwright-chromium";
+import OnlineJudge, { OnlineJudgeName } from "./OnlineJudge";
+
+export default class CS3233 extends OnlineJudge {
+  readonly onlineJudgeName = OnlineJudgeName.szkopul;
+  readonly loginUrl = "https://szkopul.edu.pl/login/";
+  readonly blockedResourcesOnSubmit: Set<string> = new Set([
+    "image",
+    "stylesheet",
+    "font",
+    "script"
+  ]);
+
+  async isLoggedIn(page: Page): Promise<boolean> {
+    const querySelector = '[data-post-url="/logout/"]';
+    return (await page.$(querySelector)) !== null;
+  }
+
+  async uploadFile(filePath: string, page: Page, langAlias: string): Promise<boolean> {
+    try {
+      const inputFile = await page.$("input#id_file[type=file]");
+      if(inputFile) await inputFile.setInputFiles(filePath); else return false;
+	  await page.click('button[type=submit]');
+      await page.waitForLoadState("domcontentloaded");
+	  return true;
+    } catch (e) {
+      console.log(e);
+      return false;
+    }
+  }
+}

--- a/app/src/Submit/OnlineJudgeFactory/Szkopul.ts
+++ b/app/src/Submit/OnlineJudgeFactory/Szkopul.ts
@@ -19,7 +19,7 @@
 import { Page } from "playwright-chromium";
 import OnlineJudge, { OnlineJudgeName } from "./OnlineJudge";
 
-export default class CS3233 extends OnlineJudge {
+export default class Szkopul extends OnlineJudge {
   readonly onlineJudgeName = OnlineJudgeName.szkopul;
   readonly loginUrl = "https://szkopul.edu.pl/login/";
   readonly blockedResourcesOnSubmit: Set<string> = new Set([
@@ -34,13 +34,14 @@ export default class CS3233 extends OnlineJudge {
     return (await page.$(querySelector)) !== null;
   }
 
-  async uploadFile(filePath: string, page: Page, langAlias: string): Promise<boolean> {
+  async uploadFile(filePath: string, page: Page, _langAlias: string): Promise<boolean> {
     try {
       const inputFile = await page.$("input#id_file[type=file]");
-      if(inputFile) await inputFile.setInputFiles(filePath); else return false;
-	  await page.click('button[type=submit]');
+      if (inputFile) await inputFile.setInputFiles(filePath);
+      else return false;
+      await page.click("button[type=submit]");
       await page.waitForLoadState("domcontentloaded");
-	  return true;
+      return true;
     } catch (e) {
       console.log(e);
       return false;

--- a/app/src/Submit/OnlineJudgeFactory/Yandex.ts
+++ b/app/src/Submit/OnlineJudgeFactory/Yandex.ts
@@ -32,7 +32,7 @@ export default class Yandex extends OnlineJudge {
   async uploadFile(filePath: string, page: Page, langAlias: string): Promise<boolean> {
     try {
       await page.selectOption("select", { value: langAlias });
-      await page.click("input[value=file]")
+      await page.click("input[value=file]");
       const inputFile = await page.$("input[type=file]");
       if (inputFile) await inputFile.setInputFiles(filePath);
       await page.click("div.problem__send > button");


### PR DESCRIPTION
 actually this only support problem-url being equal to something like `https://szkopul.edu.pl/problemset/problem/43LcdhShos7i99wnVNtQYUUK/site/?key=submit#` instead of the normal `key=statement` (and I'm not sure if it can be parsed with competitive companion either)

Is it okay to support only submit page? Or should click on the link? (is there a way to pre-modify the link?)

For now the site automatically determine the language, so it isn't necessary to define language alias.