### PR TITLE
run kitty with --single-instance flag

### DIFF
--- a/app/src/Clone/EditorCommandBuilder.ts
+++ b/app/src/Clone/EditorCommandBuilder.ts
@@ -13,7 +13,7 @@ export function getEditorCommand(terminalName: string, contestPath: string): str
     case "terminal":
       return `open -a terminal "${contestPath}"`;
     case "kitty":
-      return `kitty --directory "${contestPath}"`;
+      return `kitty --single-instance --directory "${contestPath}"`;
     case "vscode":
       return `code "${contestPath}"`;
     default:


### PR DESCRIPTION
Running a single instance of kitty using this flag reduces startup time, albeit negligibly. More importantly, it avoids polluting the Dock of MacOS systems with multiple copies of kitty.