### PR TITLE
Group contests based on online judge

### DIFF
--- a/app/src/Clone/CCServer.ts
+++ b/app/src/Clone/CCServer.ts
@@ -25,7 +25,6 @@ import { exit } from "process";
 import { spawn, spawnSync } from "child_process";
 import Util from "../Utils/Util";
 import SourceFileCreator from "../Create/SourceFileCreator";
-import * as os from "os";
 import { getEditorCommand } from "./EditorCommandBuilder";
 import chalk from "chalk";
 import Tester from "../Test/TesterFactory/Tester";
@@ -80,8 +79,7 @@ export default class CCServer {
     const interval = setInterval(() => {
       if (!this.isActive) return;
       const elapsedTime = process.hrtime(this.lastRequestTime)[0];
-      const isWindows = os.type() === "Windows_NT" || os.release().includes("Microsoft");
-      const tolerance = isWindows ? 10 : 1;
+      const tolerance = Util.isWindows() ? 4 : 1;
       if (elapsedTime >= tolerance) {
         if (serverRef) serverRef.close();
         clearInterval(interval);
@@ -92,7 +90,7 @@ export default class CCServer {
         if (command) {
           const newTerminalExec = spawn(command, { shell: true, detached: true, stdio: "ignore" });
           newTerminalExec.unref();
-          if (this.config.closeAfterClone && !isWindows) {
+          if (this.config.closeAfterClone && !Util.isWindows()) {
             const execution = spawnSync("ps", ["-o", "ppid=", "-p", `${process.ppid}`]);
             const grandParentPid = parseInt(execution.stdout.toString().trim());
             if (!Number.isNaN(grandParentPid)) {

--- a/app/src/Clone/EditorCommandBuilder.ts
+++ b/app/src/Clone/EditorCommandBuilder.ts
@@ -16,6 +16,8 @@ export function getEditorCommand(terminalName: string, contestPath: string): str
       return `kitty --directory "${contestPath}"`;
     case "vscode":
       return `code "${contestPath}"`;
+    case "neovide":
+      return `neovide "${contestPath}"`;
     default:
       return `${terminalName} "${contestPath}"`;
   }

--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -42,7 +42,7 @@ export default class Config {
   hideTestCaseInput: boolean;
   maxLinesToShowFromInput: number;
   cloneInCurrentDir: boolean;
-  sortBasedOnOnlineJudge: boolean;
+  groupContestsByJudge: boolean;
   executableFileExtension: string;
   // config for language extension
   languages: Record<string, LangConfig | undefined>;
@@ -58,7 +58,7 @@ export default class Config {
     this.hideTestCaseInput = false;
     this.maxLinesToShowFromInput = 50;
     this.cloneInCurrentDir = false;
-    this.sortBasedOnOnlineJudge = false;
+    this.groupContestsByJudge = false;
     this.executableFileExtension = "exe";
     this.languages = {
       cpp: {

--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -42,6 +42,7 @@ export default class Config {
   hideTestCaseInput: boolean;
   maxLinesToShowFromInput: number;
   cloneInCurrentDir: boolean;
+  sortBasedOnOnlineJudge: boolean;
   executableFileExtension: string;
   // config for language extension
   languages: Record<string, LangConfig | undefined>;
@@ -57,6 +58,7 @@ export default class Config {
     this.hideTestCaseInput = false;
     this.maxLinesToShowFromInput = 50;
     this.cloneInCurrentDir = false;
+    this.sortBasedOnOnlineJudge = false;
     this.executableFileExtension = "exe";
     this.languages = {
       cpp: {

--- a/app/src/Utils/Util.ts
+++ b/app/src/Utils/Util.ts
@@ -178,4 +178,43 @@ export default class Util {
   static isWindows(): boolean {
     return os.type() === "Windows_NT" || os.release().includes("Microsoft");
   }
+
+  static splitOnlineJudgeName(contestName: string): Array<string> {
+    const onlineJudgeNames = [
+      "Codeforces",
+      "CodeChef",
+      "AtCoder",
+      "HackerRank",
+      "ProjectEuler",
+      "TopCoder",
+      "CSAcademy",
+      "HackerEarth",
+      "Kattis",
+      "LeetCode",
+      "SPOJ"
+    ];
+    for (const onlineJudgeName of onlineJudgeNames) {
+      if (contestName.startsWith(onlineJudgeName)) {
+        return [onlineJudgeName, contestName.substring(onlineJudgeName.length)];
+      }
+    }
+    console.log("Online Judge not identified, saving in root directory");
+    return ["", contestName];
+  }
+
+  static getContestPath(contestName: string, config: Config): string {
+    if (config.sortBasedOnOnlineJudge) {
+      const [onlineJudgeName, splitContestName] = this.splitOnlineJudgeName(contestName);
+      if (config.cloneInCurrentDir) {
+        return Path.join(onlineJudgeName, splitContestName);
+      } else {
+        return Path.join(config.contestsDirectory, onlineJudgeName, splitContestName);
+      }
+    } else {
+      if (config.cloneInCurrentDir) {
+        return contestName;
+      }
+      return Path.join(config.contestsDirectory, contestName);
+    }
+  }
 }

--- a/app/src/Utils/Util.ts
+++ b/app/src/Utils/Util.ts
@@ -179,6 +179,25 @@ export default class Util {
     return os.type() === "Windows_NT" || os.release().includes("Microsoft");
   }
 
+  static getCodeforcesFormatedContestName(contestName: string): string {
+    let formatedContestName = contestName;
+    const prefix = "Codeforces";
+    while(formatedContestName.startsWith(prefix)) {
+      formatedContestName = formatedContestName.substring(prefix.length);
+    }
+    let match = formatedContestName.match(/(EducationalCodeforcesRound)(\d+)(Ratedfor)(Div\.\d)/);
+    if(match){
+      formatedContestName = `EducationalRound_${match[2]}_${match[4]}`
+    }
+    else{
+      let match = formatedContestName.match(/(\w*Round)(\d+)(Div\.\d)?/);
+      if(match){
+        formatedContestName = `${match[1]}_${match[2]}${match[3]?'_'+match[3]:''}`
+      }
+    }
+    return formatedContestName;
+  }
+
   static splitOnlineJudgeName(contestName: string): Array<string> {
     const onlineJudgeNames = [
       "Codeforces",
@@ -195,6 +214,9 @@ export default class Util {
     ];
     for (const onlineJudgeName of onlineJudgeNames) {
       if (contestName.startsWith(onlineJudgeName)) {
+        if(onlineJudgeName === "Codeforces") {
+          return [onlineJudgeName, this.getCodeforcesFormatedContestName(contestName)];
+        }
         return [onlineJudgeName, contestName.substring(onlineJudgeName.length)];
       }
     }

--- a/app/src/Utils/Util.ts
+++ b/app/src/Utils/Util.ts
@@ -203,7 +203,7 @@ export default class Util {
   }
 
   static getContestPath(contestName: string, config: Config): string {
-    if (config.sortBasedOnOnlineJudge) {
+    if (config.groupContestsByJudge) {
       const [onlineJudgeName, splitContestName] = this.splitOnlineJudgeName(contestName);
       if (config.cloneInCurrentDir) {
         return Path.join(onlineJudgeName, splitContestName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cpbooster",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Enhancement #95
When `sortBasedOnOnlineJudge` config option is set to true, contests are sorted bases on the online Judges
**Example**
`CodeforcesCodeforcesRound360Div.2` -> `Codeforces/CodeforcesRound360Div.2`
`AtCoderAtCoderRegularContest167` -> `AtCoder/AtCoderRegularContest167`