### PR TITLE
Fetch langAlias earlier

### DIFF
--- a/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
+++ b/app/src/Submit/OnlineJudgeFactory/OnlineJudge.ts
@@ -176,6 +176,18 @@ export default abstract class OnlineJudge {
   }
 
   async submit(filePath: string, url: string, config: Config, langAlias?: string): Promise<void> {
+    if (!langAlias) {
+      langAlias = this.getLangAlias(filePath, config);
+      if (!langAlias) {
+        console.log(
+          `${this.onlineJudgeName} alias for "${Util.getExtensionName(
+            filePath
+          )}" was not found in config file.`
+        );
+        exit(0);
+      }
+    }
+
     const browser = await chromium.launch({ headless: true });
     const context = await this.restoreSession(browser);
 
@@ -200,22 +212,7 @@ export default abstract class OnlineJudge {
     }
 
     try {
-      let result: boolean;
-      if (langAlias) {
-        result = await this.uploadFile(filePath, page, langAlias);
-      } else {
-        const langAliasFromConfig = this.getLangAlias(filePath, config);
-        if (langAliasFromConfig) {
-          result = await this.uploadFile(filePath, page, langAliasFromConfig);
-        } else {
-          console.log(
-            `${this.onlineJudgeName} alias for "${Util.getExtensionName(
-              filePath
-            )}" was not found in config file.`
-          );
-          exit(0);
-        }
-      }
+      const result = await this.uploadFile(filePath, page, langAlias);
       if (result) {
         console.log("File submitted succesfully");
       } else {


### PR DESCRIPTION
Reasoning: if the user did not set langAlias for this site/language, then this will make the tool fail immediately instead of making the user wait for a few second (and possibly login).

This does cause a change in behavior if the user did not login (it will fail _before_ letting the user login), however.