### PR TITLE
Implement custom platform directory when cloning a contest

### DIFF
--- a/app/src/Clone/CCServer.ts
+++ b/app/src/Clone/CCServer.ts
@@ -60,11 +60,6 @@ export default class CCServer {
         ? this.contestName
         : Path.join(config.contestsDirectory, this.platform, this.contestName);
       if (!fs.existsSync(contestPath)) fs.mkdirSync(contestPath, { recursive: true });
-      console.log("-------------");
-      console.log("-------------");
-      console.log(contestPath);
-      console.log("-------------");
-      console.log("-------------");
       const FilesPathNoExtension = `${Path.join(contestPath, problemData.name)}`;
       const extension = `.${config.preferredLang}`;
       const filePath = `${FilesPathNoExtension}${extension}`;

--- a/app/src/Clone/CCServer.ts
+++ b/app/src/Clone/CCServer.ts
@@ -30,19 +30,6 @@ import { getEditorCommand } from "./EditorCommandBuilder";
 import chalk from "chalk";
 import Tester from "../Test/TesterFactory/Tester";
 
-  /*
-function parseContestName(contestName) {
-  const name = contestName.trim();
-  const nameParts = name.split(" ");
-  let parsedName = "";
-  for (const part of nameParts) {
-	parsedName += part[0].toUpperCase() + part.slice(1);
-  }
-  console.log("Contest Name:", parsedName);
-  return contestName;
-}
-
-  */
 /* Competitive Companion Server */
 export default class CCServer {
   app = express();

--- a/app/src/Clone/CCServer.ts
+++ b/app/src/Clone/CCServer.ts
@@ -47,17 +47,24 @@ export default class CCServer {
 
       const problemData: ProblemData = request.body;
       problemData.name = Util.normalizeFileName(problemData.name);
-      let [platform, contestName] = problemData.group.split("-").map((str) => str.trim());
-      this.platform = platform;
-      // removes platform name from contest name
-      contestName = contestName.replace(new RegExp(this.platform, 'g'), "");
-      contestName = Util.normalizeFileName(contestName);
-      // removes extra dots
-      this.contestName = contestName.replace(/\./g, "");
+      if (this.config.createContestPlatformDirectory) {
+		let [platform, contestName] = problemData.group.split("-").map((str) => str.trim());
+		this.platform = platform;
+		// removes platform name from contest name
+		contestName = contestName.replace(new RegExp(this.platform, 'g'), "");
+		contestName = Util.normalizeFileName(contestName);
+		// removes extra dots
+		this.contestName = contestName.replace(/\./g, "");
+      } else {
+		problemData.group = Util.normalizeFileName(problemData.group);
+		this.contestName = problemData.group;
+      }
       
       const contestPath = config.cloneInCurrentDir
         ? this.contestName
-        : Path.join(config.contestsDirectory, this.platform, this.contestName);
+        : this.config.createContestPlatformDirectory
+		  ? Path.join(this.config.contestsDirectory, this.platform, this.contestName)
+		  : Path.join(this.config.contestsDirectory, problemData.group);
       if (!fs.existsSync(contestPath)) fs.mkdirSync(contestPath, { recursive: true });
       const FilesPathNoExtension = `${Path.join(contestPath, problemData.name)}`;
       const extension = `.${config.preferredLang}`;
@@ -95,7 +102,10 @@ export default class CCServer {
         clearInterval(interval);
         const contestPath = this.config.cloneInCurrentDir
           ? this.contestName
-          : Path.join(this.config.contestsDirectory, this.platform, this.contestName);
+		  : this.config.createContestPlatformDirectory
+			? Path.join(this.config.contestsDirectory, this.platform, this.contestName)
+			: Path.join(this.config.contestsDirectory, this.contestName);
+
         console.log("\n\t    DONE!\n");
         console.log(`The path to your contest folder is: "${contestPath}"`);
         console.log("\n\tHappy Coding!\n");

--- a/app/src/Clone/CCServer.ts
+++ b/app/src/Clone/CCServer.ts
@@ -47,7 +47,6 @@ export default class CCServer {
 
       const problemData: ProblemData = request.body;
       problemData.name = Util.normalizeFileName(problemData.name);
-      // this.platform = platform;
       let [platform, contestName] = problemData.group.split("-").map((str) => str.trim());
       this.platform = platform;
       // removes platform name from contest name

--- a/app/src/Config/Config.ts
+++ b/app/src/Config/Config.ts
@@ -37,6 +37,7 @@ export default class Config {
   closeAfterClone: boolean;
   showStatusPageOnSubmit: boolean;
   useUserDefaultBrowser: boolean;
+  createContestPlatformDirectory: boolean;
   // preferred language extension
   preferredLang: string;
   hideTestCaseInput: boolean;
@@ -53,6 +54,7 @@ export default class Config {
     this.closeAfterClone = false;
     this.showStatusPageOnSubmit = true;
     this.useUserDefaultBrowser = true;
+    this.createContestPlatformDirectory = true;
     this.preferredLang = "cpp";
     this.hideTestCaseInput = false;
     this.maxLinesToShowFromInput = 50;


### PR DESCRIPTION
When cloning a contest, only one unique folder with a rather long name is created.
Since the organization is not very practical, I implemented the creation of a folder with the name of the platform (Codeforces, AtCoder, etc.) and, inside of it, a second folder with the name of the cloned contest that contains the actual files.